### PR TITLE
Replace `terraform_alias`

### DIFF
--- a/completions/terraform.fish
+++ b/completions/terraform.fish
@@ -78,7 +78,7 @@ end
 
 
 set terraform_alias tf
-alias $terraform_alias "~/bin/terraform"
+alias $terraform_alias (which terraform)
 
 complete -x -c $terraform_alias -n '__fish_terraform_needs_command' -l 'version' -s 'v' -d 'Display version number and check for update'
 complete -x -c $terraform_alias -n '__fish_terraform_needs_command' -l 'help' -s 'h' -d 'Display help message'


### PR DESCRIPTION
`terraform_alias` previously referred to `~/bin/terraform` which isn't the path for all installations of Terraform (at least not for mine). Replacing this with `(which terraform)` fixes it.

Hope this helps! :slightly_smiling_face: 